### PR TITLE
Improve login generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,6 @@ fzf_options: "-i"
 # by root value.
 admin_role: "<YOUR PRIVILEGED ROLE IDENTIFIER>"
 
-# The privileged user. Usually is root
-admin_user: "root"
-
 # TSSH Easily allow to login or logout into the cluster.
 # compile the following values for handle login actions.
 teleport_proxy: "teleport.domain.com" 

--- a/defs/constants.go
+++ b/defs/constants.go
@@ -14,8 +14,6 @@ func getHomePath() string {
 	return homePath
 }
 
-var ConfigKeyAdminUser = "admin_user"
-
 var ConfigKeyAdminRole = "admin_role"
 
 var ConfigKeyTeleportProxy = "teleport_proxy"

--- a/interfaces/goteleport.go
+++ b/interfaces/goteleport.go
@@ -18,9 +18,11 @@ type goteleport struct {
 }
 
 type Goteleport interface {
-	ListRoles() ([]string, error)
 	ListHosts() ([]string, error)
 	ListLogins() ([]string, error)
+	ListRolesDetails() ([]types.TctlRole, error)
+	ShowRole(string) (types.TctlRole, error)
+	ListRoles() ([]string, error)
 	Login() error
 	Logout() error
 	CreateSshConfig() error
@@ -107,6 +109,37 @@ func (t *goteleport) ListHosts() ([]string, error) {
 	}
 
 	return hostnames, nil
+}
+
+func (t *goteleport) ListRolesDetails() ([]types.TctlRole, error) {
+	var roles []types.TctlRole
+	out, err := utils.Exec("tctl", "get", "role", "--format=json")
+	if err != nil {
+		return roles, err
+	}
+
+	err = json.Unmarshal(out, &roles)
+	if err != nil {
+		return roles, err
+	}
+
+	return roles, nil
+}
+
+func (t *goteleport) ShowRole(roleName string) (types.TctlRole, error) {
+	var roles []types.TctlRole
+	var role types.TctlRole
+	out, err := utils.Exec("tctl", "get", "role/"+roleName, "--format=json")
+	if err != nil {
+		return role, err
+	}
+
+	err = json.Unmarshal(out, &roles)
+	if err != nil {
+		return role, err
+	}
+
+	return roles[0], nil
 }
 
 func (t *goteleport) ListRoles() ([]string, error) {

--- a/services/connection.go
+++ b/services/connection.go
@@ -11,7 +11,6 @@ import (
 
 type connection struct {
 	sysadminRole string
-	sysadminUser string
 	goteleport   interfaces.Goteleport
 }
 
@@ -144,14 +143,8 @@ func NewConnectionService(user, proxy string, passwordless bool) (Connection, er
 		passwordless,
 	)
 
-	sysadminUser := viper.GetString(defs.ConfigKeyAdminUser)
-	if sysadminUser == "" {
-		sysadminUser = defs.DefaultTSHRole
-	}
-
 	return &connection{
 		goteleport:   goteleport,
 		sysadminRole: viper.GetString(defs.ConfigKeyAdminRole),
-		sysadminUser: sysadminUser,
 	}, err
 }

--- a/templates/config.go
+++ b/templates/config.go
@@ -10,13 +10,11 @@ var Config = fmt.Sprintf(`
 # TSSH configuration file
 fzf_options: "-i"
 %s: ""
-%s: "root"
 %s: "teleport.domain.com"
 %s: "my_username"
 %s: false
 `,
 	defs.ConfigKeyAdminRole,
-	defs.ConfigKeyAdminUser,
 	defs.ConfigKeyTeleportProxy,
 	defs.ConfigKeyTeleportUser,
 	defs.ConfigKeyTeleportPasswordless,

--- a/types/main.go
+++ b/types/main.go
@@ -19,6 +19,30 @@ type GoteleportCMDStatus struct {
 }
 
 type TsshConnection struct {
-	User string
-	Host string
+	User  string
+	Host  string
+	Refer string
+}
+
+type TctlRoleSpecAllowNodeLabels struct {
+	Hostname string `json:"hostname"`
+}
+
+type TctlRoleSpecAllow struct {
+	Logins     []string                    `json:"logins"`
+	NodeLabels TctlRoleSpecAllowNodeLabels `json:"node_labels"`
+}
+
+type TctlRoleSpec struct {
+	Allow TctlRoleSpecAllow `json:"allow"`
+}
+
+type TctlRoleMetadata struct {
+	Name string `json:"name"`
+}
+
+type TctlRole struct {
+	Kind     string           `json:"kind"`
+	Metadata TctlRoleMetadata `json:"metadata"`
+	Spec     TctlRoleSpec     `json:"spec"`
 }


### PR DESCRIPTION
This feat introduce a better ssh command generation.
Now using the sysadmin role declared in the configuration, the system read for available logins allowing to have multiple username for sysadmin.

Also, using the command:
`tctl get role`

The system is no more constrained to the role name for ssh connection generation.