### PR TITLE
fix: add headless flag for avoid render error

### DIFF
--- a/interfaces/goteleport.go
+++ b/interfaces/goteleport.go
@@ -79,7 +79,7 @@ func (t *goteleport) includeSSHConfig() error {
 }
 
 func (t *goteleport) getStatus() error {
-	output, err := utils.Exec("tsh", "status", "--format=json")
+	output, err := utils.Exec("tsh", "status", "--format=json", "--headless")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This fix resolve a problem related the output of the command:

`tsh status --format json`

When a security patch version is released by teleport, the following message appear:

```
A security patch is available for Teleport. Please upgrade your Cluster to vx.x.x or newer.
```

Using the headless flag resolve this problem and don't break the app when try to unmarshal JSON output.
